### PR TITLE
Update time retrieval to be thread safe

### DIFF
--- a/include/rk_logger/log.h
+++ b/include/rk_logger/log.h
@@ -75,11 +75,11 @@ void stopLogger(std::thread);
  */
 template<typename... Args>
 void logMessage(const rk::time::time_point time, const std::string funcName, const Args&... args) {
+    std::lock_guard<std::mutex> lock(logQueueMutex);
     std::ostringstream oss;
     oss << rk::time::generateTimeStamp(time); // Prefix the time stamp
     oss << "[" << std::this_thread::get_id() << "][" << funcName << "]"; // Prefix the thread id and function name
     (oss << ... << args);
-    std::lock_guard<std::mutex> lock(logQueueMutex);
     logQueue.push(oss.str());
     cv.notify_one();
 }

--- a/include/rk_logger/log_time.h
+++ b/include/rk_logger/log_time.h
@@ -80,17 +80,17 @@ extern std::function<std::string(const int)> monthFunc;
 extern std::function<std::string(const std::string, const std::string, const std::string)> dateFunc;
 
 /**
- * @brief Updates the month function at runtime.
+ * @brief Updates the month function. This function does not "update the month", but rather updates the function that formats the month.
  */
 void updateMonthFunc();
 
 /**
- * @brief Updates the date function at runtime.
+ * @brief Updates the date function. This function does not "update the date", but rather updates the function that formats the date.
  */
 void updateDateFunc();
 
 /**
- * @brief Calls all function updater functions to update functions at runtime.
+ * @brief Calls all function updater functions to update functions.
  */
 void updateTimeStampFuncs();
 


### PR DESCRIPTION
Moved the mutex so it is acquired before doing the previously not thread-safe action of constructing a std::tm object. Updated some comments on functions as well.